### PR TITLE
Add enable/DisableAll keys link

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "jest": "26.4.2",
     "prettier": "2.0.5",
     "ts-jest": "26.3.0",
+    "tslib": "2.0.1",
     "typescript": "3.9.7"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,6 +36,10 @@ export const setEnabledKey = (key: string, enabled: boolean) => {
 
 export const isKeyEnabled = (key: string) => !(config?.disabledKeys ?? []).includes(key)
 
+export const hasKeyDisabled = () => {
+  return (config?.disabledKeys?.length ?? 0) > 0
+}
+
 export const enableAllKeys = () => {
   config.disabledKeys = []
   saveConfig()

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,10 @@
+export enum SwitchActionKeys {
+  EnableAll='enable all keys',
+  DisableAll='disable all keys'
+}
+
+export const switchActionsKeysArray = Object.values(SwitchActionKeys) as string[]
+
 export interface StoreDevtoolsSwitcherConfig {
   disabledKeys?: string[]
 }
@@ -12,15 +19,29 @@ const getConfig = (defaultConfig: StoreDevtoolsSwitcherConfig = {}): StoreDevtoo
 
 let config: StoreDevtoolsSwitcherConfig
 
+const saveConfig = () => {
+  localStorage.setItem('store-devtool-switcher', JSON.stringify(config))
+}
+
 export const initConfig = (defaultConfig?: StoreDevtoolsSwitcherConfig) => {
   config = getConfig(defaultConfig)
 }
 
 export const setEnabledKey = (key: string, enabled: boolean) => {
   config.disabledKeys = enabled
-    ? (config.disabledKeys ?? []).filter(k => k !== key)
-    : [key, ...(config.disabledKeys ?? [])]
-  localStorage.setItem('store-devtool-switcher', JSON.stringify(config))
+    ? (config?.disabledKeys ?? []).filter(k => k !== key)
+    : [key, ...(config?.disabledKeys ?? [])]
+  saveConfig()
 }
 
-export const isKeyEnabled = (key: string) => !(config.disabledKeys ?? []).includes(key)
+export const isKeyEnabled = (key: string) => !(config?.disabledKeys ?? []).includes(key)
+
+export const enableAllKeys = () => {
+  config.disabledKeys = []
+  saveConfig()
+}
+
+export const disableAllKeys = (keys: string[]) => {
+  config.disabledKeys = keys
+  saveConfig()
+}

--- a/src/display-state.ts
+++ b/src/display-state.ts
@@ -1,9 +1,44 @@
-import { isKeyEnabled, setEnabledKey } from './config'
+import {
+  disableAllKeys,
+  enableAllKeys,
+  isKeyEnabled,
+  setEnabledKey,
+  SwitchActionKeys,
+  switchActionsKeysArray
+} from './config'
 
 let previousDisplayedState = {}
 
+const displayEnableAllLink = (getExtendedState) => {
+  return {
+    [SwitchActionKeys.EnableAll]: {
+      enabled: '',
+      get ['Click on "(…)" to toggle']() {
+        enableAllKeys()
+        displayState(getExtendedState())
+        return 'All keys have been enabled'
+      }
+    }
+  }
+}
+
+const displayDisableAllLink = (state, getExtendedState) => {
+  return {
+    [SwitchActionKeys.DisableAll]: {
+      enabled: '',
+      get ['Click on "(…)" to toggle']() {
+        disableAllKeys(Object.keys(state))
+        displayState(getExtendedState())
+        return 'All keys have been disabled'
+      }
+    }
+  }
+}
+
 export const displayState = state => {
-  const extendedState = Object.keys(state).reduce(
+  const extendedState = Object.keys(state)
+    .filter((item) => !switchActionsKeysArray.includes(item))
+    .reduce(
     (prev, curr) => ({
       ...prev,
       [curr]: {
@@ -16,7 +51,10 @@ export const displayState = state => {
         }
       }
     }),
-    {}
+    {
+      ...displayEnableAllLink(() => extendedState),
+      ...displayDisableAllLink(state, () => extendedState)
+    }
   )
   const identical = Object.keys(extendedState).reduce(
     (prev, curr) => prev && extendedState[curr].enabled === previousDisplayedState[curr]?.enabled,

--- a/src/display-state.ts
+++ b/src/display-state.ts
@@ -1,6 +1,7 @@
 import {
   disableAllKeys,
   enableAllKeys,
+  hasKeyDisabled,
   isKeyEnabled,
   setEnabledKey,
   SwitchActionKeys,
@@ -9,27 +10,15 @@ import {
 
 let previousDisplayedState = {}
 
-const displayEnableAllLink = (getExtendedState) => {
+const displayToggleAllLink = (state, getExtendedState) => {
+  const hasKey = hasKeyDisabled()
   return {
-    [SwitchActionKeys.EnableAll]: {
-      enabled: '',
+    [hasKey? SwitchActionKeys.EnableAll : SwitchActionKeys.DisableAll]: {
+      enabled: !hasKey,
       get ['Click on "(…)" to toggle']() {
-        enableAllKeys()
+        hasKey ? enableAllKeys() : disableAllKeys(Object.keys(state))
         displayState(getExtendedState())
-        return 'All keys have been enabled'
-      }
-    }
-  }
-}
-
-const displayDisableAllLink = (state, getExtendedState) => {
-  return {
-    [SwitchActionKeys.DisableAll]: {
-      enabled: '',
-      get ['Click on "(…)" to toggle']() {
-        disableAllKeys(Object.keys(state))
-        displayState(getExtendedState())
-        return 'All keys have been disabled'
+        return `All keys have been ${hasKey? 'enabled' : 'disabled'}`
       }
     }
   }
@@ -46,14 +35,21 @@ export const displayState = state => {
         get ['Click on "(…)" to toggle']() {
           this.enabled = !this.enabled
           setEnabledKey(curr, this.enabled)
-          console.table(extendedState)
+          const {
+            [SwitchActionKeys.DisableAll]: disableAction,
+            [SwitchActionKeys.EnableAll]: enable,
+            ...cleanExtendedState
+          } = extendedState
+          console.table({
+            ...displayToggleAllLink(state, () => cleanExtendedState),
+            ...cleanExtendedState
+          })
           return 'Updated to ' + this.enabled
         }
       }
     }),
     {
-      ...displayEnableAllLink(() => extendedState),
-      ...displayDisableAllLink(state, () => extendedState)
+      ...displayToggleAllLink(state, () => extendedState)
     }
   )
   const identical = Object.keys(extendedState).reduce(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3391,6 +3391,11 @@ ts-jest@26.3.0:
     semver "7.x"
     yargs-parser "18.x"
 
+tslib@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"


### PR DESCRIPTION
On large store, it can be handy to have a link to enable or disable all entries.

![2020-09-08_14-44-45](https://user-images.githubusercontent.com/7902756/92478080-f34bfb00-f1e1-11ea-9a1f-92eb69d8fd8c.gif)
