### PR TITLE
fix(sort-object): implement maxDeepLevel safety

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -4,4 +4,7 @@ export interface StateSanitizerOptions<State extends {}> {
   customSanitizer?: (state: State) => any
   defaultConfig?: StoreDevtoolsSwitcherConfig
   sortKeys?: 'none' | 'root' | 'deep'
+  maxSortDeepLevel?: number
 }
+
+export const DEFAULT_MAX_SORT_DEEP_LEVEL: number = 10

--- a/src/sort-object.ts
+++ b/src/sort-object.ts
@@ -1,4 +1,4 @@
-export function sortObject<T>(value: T, deep: boolean = false): T {
+export function sortObject<T>(value: T, deep: boolean = false, maxDeepLevel: number = 10, level: number = 0): T {
   return typeof value !== 'object' || value === null || Array.isArray(value)
     ? value
     : Object.keys(value)
@@ -6,7 +6,7 @@ export function sortObject<T>(value: T, deep: boolean = false): T {
         .reduce<T>(
           (res, key) => ({
             ...res,
-            [key]: deep ? sortObject(value[key], true) : value[key]
+            [key]: (deep && level < maxDeepLevel) ? sortObject(value[key], true, maxDeepLevel, level + 1) : value[key]
           }),
           {} as T
         )

--- a/src/state-sanitizer.ts
+++ b/src/state-sanitizer.ts
@@ -1,6 +1,6 @@
 import { initConfig, isKeyEnabled } from './config'
 import { displayState } from './display-state'
-import { StateSanitizerOptions } from './options'
+import { DEFAULT_MAX_SORT_DEEP_LEVEL, StateSanitizerOptions } from './options'
 import { sortObject } from './sort-object'
 
 const removeDisabledKeys = <State extends {}>(state): Partial<State> =>
@@ -22,7 +22,10 @@ export const stateSanitizer = <State extends {}>(options?: StateSanitizerOptions
     displayState(rootSortedState)
 
     const filteredState = removeDisabledKeys(rootSortedState)
-    const deepSortedState = options?.sortKeys === 'deep' ? sortObject(filteredState, true) : filteredState // Deep sort only after keys removal for perfs purpose
+    const deepSortedState =
+      options?.sortKeys === 'deep'
+        ? sortObject(filteredState, true, options?.maxSortDeepLevel ?? DEFAULT_MAX_SORT_DEEP_LEVEL)
+        : filteredState // Deep sort only after keys removal for perfs purpose
     return options?.customSanitizer ? options.customSanitizer(deepSortedState) : deepSortedState
   }
 }


### PR DESCRIPTION
- In case of circular reference, this will stop by default at level 10
- This can be overridden with the `maxSortDeepLevel` option